### PR TITLE
Replace backticks with single quotes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ I don't wanna do this any more, just wanna run multiple processes and kill them 
 # Usage
 
 ```sh
-% too --cmd `rails server` --cmd `npm start-webpack`
+% too --cmd 'rails server' --cmd 'npm start-webpack'
 ```
 
 Then you will get


### PR DESCRIPTION
This pull-request replaces backticks with single quotes in the example.

```
`rails server`
```
as appeared in your example, is extracted/executed and the output is passed to the original command, in sh, bash, csh and zsh.

I hope this makes sense to you.