### PR TITLE
Fix process teardown: kill whole tree (#529) and tear down siblings on failure (#530)

### DIFF
--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -31,7 +31,9 @@ export class Command {
     this.logger.accept(this.label, this.color, this.oneliner);
 
     const stream = child_process.spawn(this.oneliner, {
-      detached: false,
+      // detached makes each child a process-group leader, so cleanup() can
+      // signal the whole tree (shell + grandchildren) via process.kill(-pid).
+      detached: true,
       env: {
         ...process.env, ...this.env,
         PATH: this.path().join(path.delimiter),

--- a/src/lib/executor.ts
+++ b/src/lib/executor.ts
@@ -56,19 +56,23 @@ export class ParallelExecutor {
     await this.wait();
   }
   public async cleanup(signal: NodeJS.Signals): Promise<boolean[]> {
-    const promises: Promise<boolean>[] = [];
-    this.procs.forEach((proc) => {
-      promises.push(new Promise((resolve) => {
+    const promises: Promise<boolean>[] = this.procs.map((proc) => {
+      return new Promise<boolean>((resolve) => {
+        // Already exited (e.g. the job that triggered the failure): nothing to kill.
+        if (proc.exitCode !== null || proc.signalCode !== null) return resolve(true);
+        // Resolve only once the child has actually closed, so callers can await teardown.
+        proc.on("close", () => resolve(true));
         try {
+          // Negative pid signals the whole process group (requires detached children).
           if (proc.pid) process.kill(-proc.pid, signal);
+          else resolve(true);
         } catch (err) {
           const error = err as { code?: string, message?: string };
           if (error.code === "ESRCH") return resolve(true);
-          console.error((err as { message?: string }).message);
+          console.error(error.message);
           resolve(false);
         }
-        proc.on("close", () => resolve(true));
-      }));
+      });
     });
     return Promise.all(promises);
   }

--- a/src/lib/too.ts
+++ b/src/lib/too.ts
@@ -89,7 +89,9 @@ export class Too {
   async run(): Promise<number> {
     process.on("SIGINT", async () => {
       process.stdout.write("\n[too] \uD83D\uDC4B Received SIGINT, shutting down...\n");
-      await this.main.cleanup("SIGINT");
+      // Terminate with SIGTERM, not SIGINT: a non-interactive shell sets SIGINT to
+      // ignored for backgrounded (`cmd &`) jobs, so re-sending SIGINT would leak them.
+      await this.main.cleanup("SIGTERM");
       await this.post.run();
       process.stdout.write("[too] \uD83D\uDC4B All processes terminated.\n");
       process.exit(0);
@@ -103,6 +105,9 @@ export class Too {
     try {
       await this.main.run();
     } catch (e) {
+      // One job failed; tear down the surviving siblings before post, otherwise
+      // they leak (the SIGINT handler is the only other place that cleans up).
+      await this.main.cleanup("SIGTERM");
       await this.post.run();
       return (e as { code: number }).code || 1;
     }

--- a/tests/executor.spec.ts
+++ b/tests/executor.spec.ts
@@ -43,14 +43,16 @@ describe("ParallelExecutor.cleanup", () => {
       {},
       logger,
     );
-    const running = ex.run();
+    // run() rejects once the job is killed by a signal (wait() sees a non-zero exit);
+    // attach the catch synchronously so there is never an unhandled-rejection window.
+    const running = ex.run().catch(() => undefined);
 
     await waitFor(() => fs.existsSync(pidfile) && fs.readFileSync(pidfile, "utf8").trim().length > 0);
     const grandchildPid = parseInt(fs.readFileSync(pidfile, "utf8").trim(), 10);
     expect(alive(grandchildPid)).toBe(true);
 
     await ex.cleanup("SIGTERM");
-    await running.catch(() => undefined); // killed by signal -> wait() rejects; that's expected
+    await running;
 
     await waitFor(() => !alive(grandchildPid));
     expect(alive(grandchildPid)).toBe(false);

--- a/tests/executor.spec.ts
+++ b/tests/executor.spec.ts
@@ -1,0 +1,82 @@
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { ParallelExecutor } from "../src/lib/executor";
+import { Logger } from "../src/lib/logger";
+import { Too } from "../src/lib/too";
+
+class NoopLogger extends Logger {
+  stage(): void { /* noop */ }
+  accept(): void { /* noop */ }
+  output(): void { /* noop */ }
+}
+
+const logger = new NoopLogger();
+
+/** Returns true if a process with the given pid is still alive. */
+function alive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as { code?: string }).code !== "ESRCH";
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 50));
+  }
+}
+
+describe("ParallelExecutor.cleanup", () => {
+  it("terminates the whole process tree, not just the direct child (#529)", async () => {
+    const pidfile = path.join(os.tmpdir(), `too-grandchild-${process.pid}.pid`);
+    if (fs.existsSync(pidfile)) fs.unlinkSync(pidfile);
+
+    // The shell backgrounds a `sleep` grandchild and records its pid, then waits.
+    const ex = new ParallelExecutor(
+      "MAIN",
+      { jobs: [{ run: `sleep 30 & echo $! > ${pidfile}; wait` }] },
+      {},
+      logger,
+    );
+    const running = ex.run();
+
+    await waitFor(() => fs.existsSync(pidfile) && fs.readFileSync(pidfile, "utf8").trim().length > 0);
+    const grandchildPid = parseInt(fs.readFileSync(pidfile, "utf8").trim(), 10);
+    expect(alive(grandchildPid)).toBe(true);
+
+    await ex.cleanup("SIGTERM");
+    await running.catch(() => undefined); // killed by signal -> wait() rejects; that's expected
+
+    await waitFor(() => !alive(grandchildPid));
+    expect(alive(grandchildPid)).toBe(false);
+
+    fs.unlinkSync(pidfile);
+  }, 20000);
+
+  it("resolves immediately for already-exited processes", async () => {
+    const ex = new ParallelExecutor("MAIN", { jobs: [{ run: "true" }] }, {}, logger);
+    await ex.run(); // job exits 0 on its own
+    await expect(ex.cleanup("SIGTERM")).resolves.toEqual([true]);
+  }, 10000);
+});
+
+describe("Too failure path", () => {
+  it("tears down surviving sibling jobs when one job fails (#530)", async () => {
+    const too = await Too.direct(['node -e "process.exit(1)"', "sleep 30"]);
+    too.logger = logger;
+    too.main.logger = logger;
+
+    const code = await too.run();
+    expect(code).toBe(1);
+
+    const sleepProc = too.main.procs.find((p) => /sleep/.test((p.spawnargs || []).join(" ")));
+    expect(sleepProc?.pid).toBeDefined();
+    await waitFor(() => !alive(sleepProc!.pid!));
+    expect(alive(sleepProc!.pid!)).toBe(false);
+  }, 20000);
+});

--- a/tests/executor.spec.ts
+++ b/tests/executor.spec.ts
@@ -13,6 +13,10 @@ class NoopLogger extends Logger {
 
 const logger = new NoopLogger();
 
+// These tests spawn real POSIX shells and rely on process-group signalling
+// (process.kill(-pid), `cmd &`, SIGTERM). That model is POSIX-only, so skip on Windows.
+const itPosix = process.platform === "win32" ? it.skip : it;
+
 /** Returns true if a process with the given pid is still alive. */
 function alive(pid: number): boolean {
   try {
@@ -32,7 +36,7 @@ async function waitFor(predicate: () => boolean, timeoutMs = 5000): Promise<void
 }
 
 describe("ParallelExecutor.cleanup", () => {
-  it("terminates the whole process tree, not just the direct child (#529)", async () => {
+  itPosix("terminates the whole process tree, not just the direct child (#529)", async () => {
     const pidfile = path.join(os.tmpdir(), `too-grandchild-${process.pid}.pid`);
     if (fs.existsSync(pidfile)) fs.unlinkSync(pidfile);
 
@@ -60,7 +64,7 @@ describe("ParallelExecutor.cleanup", () => {
     fs.unlinkSync(pidfile);
   }, 20000);
 
-  it("resolves immediately for already-exited processes", async () => {
+  itPosix("resolves immediately for already-exited processes", async () => {
     const ex = new ParallelExecutor("MAIN", { jobs: [{ run: "true" }] }, {}, logger);
     await ex.run(); // job exits 0 on its own
     await expect(ex.cleanup("SIGTERM")).resolves.toEqual([true]);
@@ -68,7 +72,7 @@ describe("ParallelExecutor.cleanup", () => {
 });
 
 describe("Too failure path", () => {
-  it("tears down surviving sibling jobs when one job fails (#530)", async () => {
+  itPosix("tears down surviving sibling jobs when one job fails (#530)", async () => {
     const too = await Too.direct(['node -e "process.exit(1)"', "sleep 30"]);
     too.logger = logger;
     too.main.logger = logger;


### PR DESCRIPTION
## Summary

Makes `too`'s process teardown actually terminate the spawned process trees, fixing two related bugs:

- **#529** — `cleanup()` was a no-op programmatically (`detached: false` + `process.kill(-pid)` → `ESRCH`, swallowed). It only appeared to work interactively because the TTY broadcasts SIGINT to the foreground group.
- **#530** — when one `main` job failed, the surviving sibling jobs were leaked (the failure path never called `cleanup()`).

## Closes

Closes #529
Closes #530

## Changes

- `command.ts`: spawn children with `detached: true` so each is a process-group leader, enabling `process.kill(-pid)` to signal the whole tree (shell + grandchildren).
- `executor.ts`: `cleanup()` resolves only after each child emits `close`, and short-circuits for already-exited procs.
- `too.ts`:
  - SIGINT handler now sends **SIGTERM** (not SIGINT) when killing. A non-interactive shell sets `SIGINT` to *ignored* for backgrounded (`cmd &`) jobs, so re-sending SIGINT would leak them. Now that children are isolated in their own group (no longer reached by the TTY's SIGINT), the handler is solely responsible for teardown and must use a signal the children honor.
  - main failure path calls `main.cleanup("SIGTERM")` before `post`, tearing down siblings.
- `tests/executor.spec.ts`: new tests for process-tree kill and sibling teardown.

## Test Plan

Mirrors the acceptance criteria of #529 and #530.

### #529
- [x] [LOGIC] A `main` job that spawns its own child (`sleep 30 & wait`) is fully terminated by `cleanup()` — neither shell nor grandchild survives
- [x] [LOGIC] `cleanup()` resolves only after each tracked child has closed (and immediately for already-exited procs)
- [x] [BUILD] `npm run build` and `npm run lint` complete without errors
- [x] [LOGIC] `npm test` passes, including the new process-tree teardown test

### #530
- [x] [LOGIC] Given two `main` jobs where one exits non-zero quickly and the other is long-running, after `run()` returns the long-running job is no longer alive
- [x] [LOGIC] `post` still runs after the failure
- [x] [BUILD] `npm run build` and `npm run lint` complete without errors
- [x] [LOGIC] `npm test` passes, including a regression test for sibling teardown on failure

## Verification

Also verified the real `Ctrl+C` path end-to-end (out of band): launched `too -c "sleep 60 & echo $! > f; wait"`, sent SIGINT to the `too` process, and confirmed the backgrounded `sleep` grandchild is terminated and `too` exits cleanly (`[sleep] exit code SIGTERM`, `[too] 👋 All processes terminated.`). Before this PR the grandchild leaked.
