### PR TITLE
Update and tidy CI workflow (Node matrix, action versions, fail-fast, bin smoke test)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,33 +9,39 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18.x, 20.x, 22.x]
+        node-version: [20.x, 22.x, 24.x]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
+        cache: 'npm'
     - run: npm ci
     - run: npm run build
     - run: npm run lint
     - run: npm test -- --coverage
-    # - run: npm run test:bin
+    # The binary smoke test uses POSIX shell builtins (sleep/echo), so skip it on Windows.
+    - name: Smoke-test the built binary
+      if: runner.os != 'Windows'
+      run: npm run test:bin
   coverage:
     needs: build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Use Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: 20.x
+        node-version: 24.x
+        cache: 'npm'
     - run: npm ci
     - run: npm test -- --coverage
-    - uses: codecov/codecov-action@v4
+    - uses: codecov/codecov-action@v7
       with:
-        file: ./coverage/coverage-final.json
+        files: ./coverage/coverage-final.json
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Updates and tidies `.github/workflows/node.js.yml`: current Node matrix, current action versions (no more deprecation warnings), `fail-fast: false` for diagnosable matrix failures, npm caching, and a re-enabled binary smoke test.

## Closes

Closes #535

## Changes

- **Node matrix** `[18.x, 20.x, 22.x]` → `[20.x, 22.x, 24.x]` — drop EOL Node 18, add current LTS 24.
- **Action bumps** to latest majors (Node 24 action runtime → no more "Node.js 20 actions are deprecated" warnings):
  - `actions/checkout@v4` → `@v6`
  - `actions/setup-node@v4` → `@v6`
  - `codecov/codecov-action@v4` → `@v7` (and fixed its input `file:` → `files:`, renamed in v4+)
- **`fail-fast: false`** — a single failing matrix cell no longer cancels the other 9 (this masked the real failure during #534).
- **`cache: 'npm'`** on `setup-node` for faster cold installs.
- **Re-enabled `npm run test:bin`** as a smoke test, gated with `if: runner.os != 'Windows'` (it uses POSIX `sleep`/`echo` not portable to `cmd.exe`).
- `coverage` job kept as-is (minimal scope), only the action/version/cache updates applied.

## Test Plan

Mirrors #535's acceptance criteria. `[BUILD]` items are verified by **this PR's own CI run**.

- [ ] [BUILD] CI matrix runs on `20.x`, `22.x`, `24.x` and no longer includes Node 18
- [ ] [BUILD] A CI run produces no "Node.js 20 actions are deprecated" warnings
- [ ] [BUILD] With `fail-fast: false`, a single failing matrix cell does not cancel the others (verified by inspection of the workflow; cannot be exercised on a green run)
- [ ] [BUILD] The built binary is smoke-tested on ubuntu/macOS (`npm run test:bin`) and passes
- [ ] [BUILD] `npm ci` uses the `setup-node` npm cache
- [ ] [BUILD] Coverage is uploaded to Codecov successfully with `codecov-action@v7`

## Verification

Ran the full workflow command set locally on Node v24.13.1 (the new top of the matrix): `npm run build`, `npm run lint`, `npm test -- --coverage` (7 passed), and the re-enabled `npm run test:bin` (binary launches, multiplexes output, exits cleanly). YAML validated via `js-yaml` parse.
