### PR TITLE
Fix command-string tokenization: `=` in commands (#295) and leading env assignments (#532)

### DIFF
--- a/src/lib/args.ts
+++ b/src/lib/args.ts
@@ -14,7 +14,13 @@ export class Args {
     public parse(argv: string[]): string[] {
         this.raw = argv.slice(2);
         const all = this.raw.reduce<string[]>((ctx, v) => {
-            if (/=/.test(v)) { return ctx.concat(v.split("=")); }
+            // Desugar `--flag=value` only for flag-like tokens, splitting on the
+            // first `=` so command values (e.g. `-c 'vite --port=5173'`) and
+            // values that themselves contain `=` pass through intact. (#295)
+            if (/^-/.test(v) && v.includes("=")) {
+                const i = v.indexOf("=");
+                return ctx.concat([v.slice(0, i), v.slice(i + 1)]);
+            }
             return ctx.concat([v]);
         }, []);
         const rest = [];

--- a/src/lib/command.ts
+++ b/src/lib/command.ts
@@ -19,7 +19,12 @@ export class Command {
     public logger: Logger = new DefaultLogger(),
     label?: string,
   ) {
-    this.command = this.oneliner.split(" ")[0];
+    // The binary is the first token that is not a leading `KEY=value` env
+    // assignment (e.g. `FOO=bar node app.js` resolves to `node`, not `FOO=bar`). (#532)
+    const tokens = this.oneliner.trim().split(/\s+/);
+    let i = 0;
+    while (i < tokens.length - 1 && /^[A-Za-z_]\w*=/.test(tokens[i])) i++;
+    this.command = tokens[i] || "";
     this.label = label || this.command;
   }
 

--- a/tests/args.spec.ts
+++ b/tests/args.spec.ts
@@ -31,6 +31,26 @@ describe("Args", () => {
       args.parse(["/bin/node", "foobaa", "-f", "hogera"]);
       expect(args.get("foo")).toEqual(["hogera"]);
     });
+
+    it("keeps `=` inside a -c command value intact (#295)", () => {
+      // Fresh spec (not the shared `specs` singleton, whose value array other
+      // tests mutate) so this asserts only on what this parse produced.
+      const cmdSpec = {
+        add: (val: string[], _flag: unknown, next: string) => val.push(next),
+        flags: ["-c", "--cmd"],
+        name: "cmd",
+        value: [] as string[],
+      };
+      const args = new Args([cmdSpec]);
+      args.parse(["/bin/node", "too", "-c", "vite --port=5173"]);
+      expect(args.get("cmd")).toEqual(["vite --port=5173"]);
+    });
+
+    it("desugars --flag=value, splitting on the first `=` only", () => {
+      const args = new Args([examplespec()]);
+      args.parse(["/bin/node", "too", "--foo=bar=baz"]);
+      expect(args.get("foo")).toEqual(["bar=baz"]);
+    });
   });
 
 });

--- a/tests/command.spec.ts
+++ b/tests/command.spec.ts
@@ -1,0 +1,50 @@
+import { Command } from "../src/lib/command";
+import { Logger } from "../src/lib/logger";
+
+class NoopLogger extends Logger {
+  stage(): void { /* noop */ }
+  accept(): void { /* noop */ }
+  output(): void { /* noop */ }
+}
+const logger = new NoopLogger();
+
+// Inline `KEY=value cmd` is POSIX shell syntax (cmd.exe uses `set ...`), so the
+// execution test is POSIX-only. The label-derivation tests are pure string logic.
+const itPosix = process.platform === "win32" ? it.skip : it;
+
+describe("Command binary/label derivation", () => {
+  it("derives the binary after leading env assignments (#532)", () => {
+    expect(new Command("FOO=bar node app.js").label).toBe("node");
+    expect(new Command("A=1 B=2 npm run dev").label).toBe("npm");
+  });
+
+  it("uses the first token when there are no assignments", () => {
+    expect(new Command("echo hello world").label).toBe("echo");
+  });
+
+  it("tolerates extra whitespace between tokens", () => {
+    expect(new Command("  FOO=bar   node   app.js").label).toBe("node");
+  });
+
+  it("falls back to the only token when the command is bare env-like", () => {
+    // No actual command following the assignment: keep the last token.
+    expect(new Command("FOO=bar").label).toBe("FOO=bar");
+  });
+});
+
+describe("Command execution", () => {
+  itPosix("runs a command with a leading env assignment instead of failing lookup (#532)", async () => {
+    const cmd = new Command(
+      `FOO=bar node -e "process.exit(process.env.FOO === 'bar' ? 0 : 1)"`,
+      {},
+      undefined,
+      logger,
+    );
+    await expect(cmd.exec()).resolves.toBe(0);
+  }, 10000);
+
+  itPosix("still rejects a genuinely missing binary with code 127", async () => {
+    const cmd = new Command("definitely-not-a-real-binary-xyz", {}, undefined, logger);
+    await expect(cmd.exec()).rejects.toMatchObject({ code: 127 });
+  }, 10000);
+});


### PR DESCRIPTION
## Summary

Fixes two related command-string tokenization bugs:

- **#295** — `too -c 'vite --port=5173'` shredded the command (the arg parser split *every* token containing `=`, including the `-c` value).
- **#532** — `too -c 'FOO=bar node app.js'` failed with `command not found: FOO=bar` (the binary was derived as the first whitespace token, i.e. the env assignment).

## Closes

Closes #295
Closes #532

## Changes

- `src/lib/args.ts`: `parse()` now desugars `--flag=value` only for flag-like tokens (`^-`) and splits on the **first** `=` only. Command values and values containing `=` (e.g. `arg=with=equals`) pass through intact.
- `src/lib/command.ts`: the binary is derived as the first token that is **not** a leading `KEY=value` env assignment, so `FOO=bar node app.js` resolves to `node` (and the auto-label is correct). Genuinely missing binaries still reject with code 127.
- Tests: `args.spec.ts` gains `=`-passthrough and first-`=`-split cases; new `command.spec.ts` covers binary/label derivation and execution (the inline-env execution test is POSIX-gated, since `KEY=value cmd` is POSIX shell syntax).

## Test Plan

Mirrors the acceptance criteria of #295 and #532. `[LOGIC]`/`[BUILD]` were executed locally (lint + build + `npm test` = 15 passed) and confirmed end-to-end against the built binary.

### #295
- [x] [LOGIC] `too -c 'vite --port=5173'` passes `--port=5173` to the command intact (verified: `echo started --port=5173` → `started --port=5173`)
- [x] [LOGIC] A value with multiple `=` (`arg=with=equals`) is preserved
- [x] [LOGIC] `--flag=value` flags are still desugared (splitting on the first `=`)
- [x] [BUILD] `npm run build` and `npm run lint` pass
- [x] [LOGIC] `npm test` passes

### #532
- [x] [LOGIC] `FOO=bar node ...` runs instead of rejecting with `command not found: FOO=bar` (verified: child sees `FOO=bar`)
- [x] [LOGIC] The derived label is the real binary (`node`/`npm`), not the assignment
- [x] [LOGIC] A genuinely missing binary still rejects with code 127
- [x] [BUILD] `npm run build` and `npm run lint` pass
- [x] [LOGIC] `npm test` passes

## Verification

End-to-end against `dist/bin/too.js`:
- `#295`: `-c 'echo started --port=5173'` → `[echo] started --port=5173`; `-c 'printf "%s\n" arg=with=equals'` → `arg=with=equals`.
- `#532`: `-c 'FOO=bar node -e "console.log(process.env.FOO)"'` → `[node] FOO=bar` (previously `command not found: FOO=bar`).
