### PR TITLE
Honor ignore_error for prep/post steps (#531)

### DIFF
--- a/src/lib/executor.ts
+++ b/src/lib/executor.ts
@@ -23,9 +23,20 @@ export class SequentialExecutor {
   async run() {
     if (this.steps.length === 0) return;
     this.logger.stage(this.state);
-    for (const step of this.steps) {
+    for (let i = 0; i < this.steps.length; i++) {
+      const step = this.steps[i];
       step.env = { ...step.env, ...this.env };
-      await step.exec();
+      try {
+        await step.exec();
+      } catch (e) {
+        // Honor `ignore_error`: log the failure and continue instead of aborting
+        // the stage (e.g. `post: pkill datastore`, which exits non-zero when no
+        // process matches). Any failure is swallowed, including command-not-found. (#531)
+        if (!this.definition.steps[i]?.ignore_error) throw e;
+        const err = e as { code?: number | string; message?: string; msg?: string };
+        const reason = err.message || err.msg || `exit code ${err.code}`;
+        this.logger.output(step.label, step.color, "", `ignored error: ${reason}`);
+      }
     }
   }
 }

--- a/tests/executor.spec.ts
+++ b/tests/executor.spec.ts
@@ -1,7 +1,7 @@
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { ParallelExecutor } from "../src/lib/executor";
+import { ParallelExecutor, SequentialExecutor } from "../src/lib/executor";
 import { Logger } from "../src/lib/logger";
 import { Too } from "../src/lib/too";
 
@@ -12,6 +12,16 @@ class NoopLogger extends Logger {
 }
 
 const logger = new NoopLogger();
+
+// Records what reached the logger, so tests can assert which steps ran / were logged.
+class RecordingLogger extends Logger {
+  public outputs: string[] = [];
+  stage(): void { /* noop */ }
+  accept(): void { /* noop */ }
+  output(_label: string, _color: string, stdout: Buffer | string, stderr: Buffer | string): void {
+    this.outputs.push(`${stdout}${stderr}`);
+  }
+}
 
 // These tests spawn real POSIX shells and rely on process-group signalling
 // (process.kill(-pid), `cmd &`, SIGTERM). That model is POSIX-only, so skip on Windows.
@@ -85,4 +95,57 @@ describe("Too failure path", () => {
     await waitFor(() => !alive(sleepProc!.pid!));
     expect(alive(sleepProc!.pid!)).toBe(false);
   }, 20000);
+});
+
+describe("SequentialExecutor ignore_error (#531)", () => {
+  // The exec() of each step is stubbed so the branch logic is tested deterministically
+  // and cross-platform (no real spawning / shell-quoting concerns).
+  function executorWith(
+    steps: { label: string; ignore_error?: boolean }[],
+    behaviors: (() => Promise<number>)[],
+    rec: RecordingLogger,
+  ): SequentialExecutor {
+    const def = { steps: steps.map((s) => ({ run: `cmd-${s.label}`, label: s.label, ignore_error: s.ignore_error })) };
+    const ex = new SequentialExecutor("PREP", def, {}, rec);
+    ex.steps.forEach((cmd, i) => { cmd.exec = behaviors[i]; });
+    return ex;
+  }
+
+  it("continues the stage when an ignored step fails, and logs it", async () => {
+    const rec = new RecordingLogger();
+    const second = jest.fn(async () => 0);
+    const ex = executorWith(
+      [{ label: "boom", ignore_error: true }, { label: "ok" }],
+      [async () => { throw { code: 3, message: "boom failed" }; }, second],
+      rec,
+    );
+    await expect(ex.run()).resolves.toBeUndefined();
+    expect(second).toHaveBeenCalled();
+    expect(rec.outputs.some((o) => /ignored error/.test(o))).toBe(true);
+  });
+
+  it("still aborts the stage when a non-ignored step fails", async () => {
+    const rec = new RecordingLogger();
+    const second = jest.fn(async () => 0);
+    const ex = executorWith(
+      [{ label: "boom" }, { label: "ok" }],
+      [async () => { throw { code: 3, message: "boom failed" }; }, second],
+      rec,
+    );
+    await expect(ex.run()).rejects.toMatchObject({ code: 3 });
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it("ignores a command-not-found (127) failure too", async () => {
+    const rec = new RecordingLogger();
+    const second = jest.fn(async () => 0);
+    const ex = executorWith(
+      [{ label: "missing", ignore_error: true }, { label: "ok" }],
+      [async () => { throw { code: 127, msg: "command not found: nope" }; }, second],
+      rec,
+    );
+    await expect(ex.run()).resolves.toBeUndefined();
+    expect(second).toHaveBeenCalled();
+    expect(rec.outputs.some((o) => /command not found/.test(o))).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

Honors the `ignore_error` flag on `prep`/`post` steps. It has been in the schema since the original PoC but was never wired, so a step like `post: pkill datastore` (which exits non-zero when nothing matches) aborted the stage.

## Closes

Closes #531

## Changes

- `src/lib/executor.ts`: `SequentialExecutor.run()` iterates by index so each `Command` correlates with its `definition.steps[i]`, and wraps `step.exec()` in try/catch. When `ignore_error` is set, the failure is logged via the existing `logger.output` channel and the stage continues; otherwise it propagates and aborts (unchanged).
- Any failure is swallowed — non-zero exit **and** command-not-found (127). The flag applies only to `SequentialExecutor` (prep/post); an ignored failure does not affect too's exit code. `Command` and `Too.run()` are unchanged; `main` (parallel) jobs are unaffected.
- `tests/executor.spec.ts`: added ignored / non-ignored / 127 branch tests (stubbed `exec` for deterministic, cross-platform coverage).

## Test Plan

Mirrors #531's acceptance criteria.

- [x] [LOGIC] A `prep`/`post` step with `ignore_error: true` that exits non-zero does not abort the stage; subsequent steps still run
- [x] [LOGIC] An ignored failure emits a visible (stderr) log line identifying the step
- [x] [LOGIC] A step with `ignore_error: true` whose binary is missing (exit 127) is also ignored and the stage continues
- [x] [LOGIC] A step **without** `ignore_error` that exits non-zero still aborts the stage (unchanged behavior)
- [x] [LOGIC] When only an ignored `post` step fails, `too` still exits `0`
- [x] [BUILD] `npm run build` and `npm run lint` complete without errors
- [x] [LOGIC] `npm test` passes (18 tests), including the ignored / non-ignored / 127 branches

## Verification

End-to-end against `dist/bin/too.js` with a too-file:
- With `ignore_error`: a missing-binary prep step (`ignored error: command not found: ...`) and an `exit 5` post step (`ignored error: Command failed: ...`) both log and continue; the following steps run; `too` exits `0`.
- Without `ignore_error`: an `exit 5` prep step aborts — subsequent prep/main steps are skipped and `too` exits `5`.
