### PR TITLE
Align example/too.local.yaml include with the loader; document include.env_files (#533)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,24 @@ then
 % too ./too.local.yaml
 ```
 
+## Including env files
+
+You can merge `KEY=value` env files into the environment with `include.env_files`.
+Paths are resolved from the current working directory.
+
+```yaml
+# too.local.yaml
+include:
+  env_files:
+  - ./example/secrets.env   # KEY=value lines, merged into the environment
+main:
+  jobs:
+  - run: echo $API_TOKEN
+```
+
+`env_files` is the only supported include form; the listed files are read as
+`KEY=value` pairs (not as nested too-files). See `example/too.local.yaml`.
+
 # Install
 
 ```sh

--- a/example/secrets.env
+++ b/example/secrets.env
@@ -1,0 +1,2 @@
+API_TOKEN=replace-me
+SLACK_WEBHOOK=https://example.invalid/hook

--- a/example/too.local.yaml
+++ b/example/too.local.yaml
@@ -19,12 +19,11 @@ version: 0
 #     validate:
 #     - run: gcloud auth list
 
+# `include.env_files` merges KEY=value env files into the environment. This is the
+# only supported include form today; nested too-file includes are not implemented.
 include:
-  - secrets.local.yaml
-  - too.local.extends.yaml
-# must_include:
-#   - xxx
-#   - yyy
+  env_files:
+  - ./example/secrets.env
 
 env:
   PROJECT_ID: triax-football

--- a/tests/too.spec.ts
+++ b/tests/too.spec.ts
@@ -1,0 +1,18 @@
+import { Too } from "../src/lib/too";
+
+// Too.parse() resolves the file's `var` generators, and example/too.local.yaml's
+// `var.DATE` runs `date '+...'` (POSIX shell syntax), so this is POSIX-only.
+const itPosix = process.platform === "win32" ? it.skip : it;
+
+describe("Too.parse include.env_files (#533)", () => {
+  itPosix("loads the example's declared env files into the environment", async () => {
+    const too = await Too.parse("example/too.local.yaml");
+    // From example/secrets.env
+    expect(too.env.API_TOKEN).toBe("replace-me");
+    expect(too.env.SLACK_WEBHOOK).toBe("https://example.invalid/hook");
+    // Static env: still present alongside the included values
+    expect(too.env.PROJECT_ID).toBe("triax-football");
+    // And propagated to the stages, so jobs can see them
+    expect(too.main.env.API_TOKEN).toBe("replace-me");
+  });
+});


### PR DESCRIPTION
## Summary

`example/too.local.yaml` declared includes as a top-level list (`include: [secrets.local.yaml, too.local.extends.yaml]`), but the loader only reads `include.env_files`, so the includes were silently dropped. The `.extends` entry also implied nested too-file includes, which aren't implemented. This aligns the example with the loader and documents the supported shape.

## Closes

Closes #533

## Changes

- `example/too.local.yaml`: switched to `include.env_files` pointing at a real committed env file, with a comment noting `env_files` is the only supported include form (nested too-file includes are not implemented).
- `example/secrets.env`: placeholder `KEY=value` env file the example includes (no comment lines — the loader doesn't skip them).
- `README.md`: documented `include.env_files` (the supported shape) matching `src/lib/file.ts`.
- `tests/too.spec.ts`: asserts `Too.parse` loads the example's env files into the environment and propagates them to stages (POSIX-gated, since the example's `var.DATE` runs `date`).

## Scope

- **In scope:** make example + README + loader agree on the supported `include.env_files` shape.
- **Out of scope:** nested/`extends` too-file includes (a separate feature, called out in the issue).

## Test Plan

Mirrors #533's acceptance criteria.

- [x] [LOGIC] `example/too.local.yaml` loads its declared includes (env vars become available to jobs) rather than silently dropping them
- [x] [MANUAL] README documents the supported `include` shape and it matches `src/lib/file.ts`
- [x] [BUILD] `npm run build` and `npm run lint` complete without errors

## Verification

- Unit: `tests/too.spec.ts` — `Too.parse("example/too.local.yaml")` exposes `API_TOKEN`/`SLACK_WEBHOOK` (from the include) plus static `PROJECT_ID`, and they propagate to `too.main.env`.
- E2e against `dist/bin/too.js`: a too-file with `include.env_files: [./example/secrets.env]` and `run: echo "API_TOKEN=$API_TOKEN"` prints `API_TOKEN=replace-me`.
- The full `example/too.local.yaml` isn't run end-to-end (it requires `gcloud`/`go`/`npm` dev servers); include-loading is verified at the parse layer where it happens.
