### PR TITLE
Publish only dist/ via files allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.2.0",
   "description": "Combine multiple processes' Stdout/Stderr/SIGINT to keep them all foreground",
   "type": "module",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "validate": "npm run lint && npm run build && npm link && too -c 'echo foo' -c 'sleep 5' -c 'gcloud beta emulators datastore start --project pricealert-jp' -c 'echo bar'",


### PR DESCRIPTION
## Summary

Adds `"files": ["dist"]` to `package.json` so the npm package ships only built output.

## Why

`npm publish --dry-run` showed the tarball also included dev-only files — `CLAUDE.md`, `Makefile`, `eslint.config.js`, `jest.config.cjs` — because `.npmignore` didn't exclude them. A `files` allowlist is the robust fix (also future-proof against new dev files). `README.md`/`LICENSE`/`package.json` are always included by npm regardless.

## Result (npm publish --dry-run)

Before: 17 entries incl. CLAUDE.md, Makefile, eslint.config.js, jest.config.cjs.
After: `dist/` (9 files) + `LICENSE` + `README.md` + `package.json` only.

## Test Plan

- [ ] [BUILD] `npm run build` / `npm run lint` pass
- [ ] [BUILD] `npm publish --dry-run` contains only `dist/`, `README.md`, `LICENSE`, `package.json` (no dev files)